### PR TITLE
master is worker

### DIFF
--- a/include/ThreadPool.hh
+++ b/include/ThreadPool.hh
@@ -41,6 +41,7 @@ public:
                                         m_promises[mypromise].set_value();
                                 });
                 }
+                m_taskQueue.pop()(); // master thread is also a worker
                 Finish();
         }
         template<typename InputIt, typename T>
@@ -57,9 +58,10 @@ public:
                     while (threadBegin != threadEnd) {
                         *(threadOutput++) = func(*(threadBegin++));
                     }
-                    m_promises[mypromise].set_value();
+                    m_promises[mypromise].set_value(); // master thread is also a worker
                 });
             }
+            m_taskQueue.pop()();
             Finish();
         }
 

--- a/src/ThreadPool.cc
+++ b/src/ThreadPool.cc
@@ -1,14 +1,14 @@
 #include "ThreadPool.hh"
 
 ThreadPool::ThreadPool(uint32_t numthreads) : m_nthreads(numthreads), m_stopWorkers(false) {
-        for (uint32_t i=0; i<numthreads;i++) {
-                m_workers.emplace_back(&ThreadPool::Worker, this);
-        }
+    for (uint32_t i=0; i<numthreads-1;i++) { // -1 b/c main thread is also a worker
+        m_workers.emplace_back(&ThreadPool::Worker, this);
+    }
 }
 ThreadPool::~ThreadPool() {
-        m_stopWorkers = true;
-        m_taskQueue.join();
-        JoinAll();
+    m_stopWorkers = true;
+    m_taskQueue.join();
+    JoinAll();
 }
 
 void ThreadPool::Worker() {
@@ -25,7 +25,7 @@ void ThreadPool::Worker() {
     }
 }
 void ThreadPool::JoinAll() {
-        for (auto& worker : m_workers) { worker.join(); }
+    for (auto& worker : m_workers) { worker.join(); }
 }
 void ThreadPool::Finish() {
     for (auto& promise : m_promises) promise.get_future().get();


### PR DESCRIPTION
Main changes are in ThreadPool.hh/cc. Simply put, instead of just having the main thread (which called ParallelFor) wait, it pops one of the tasks of the queue and executes it. Thus the number of std::thread workers is NUM_THREADS-1, so that there are a total of NUM_THREADS (including the master) running at any one time.

@jbradt Did this as a pull request just so you would be aware. I will merge it in. (Last pull request had the wrong destination)
